### PR TITLE
proposed fix: set curr_src.h is to bottom_height before drawing botto…

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4426,6 +4426,7 @@ bool SDL_RenderTexture9Grid(SDL_Renderer *renderer, SDL_Texture *texture, const 
 
     // Lower-right corner
     curr_src.y = srcrect->y + srcrect->h - bottom_height;
+    curr_src.h = bottom_height;
     curr_dst.y = dstrect->y + dstrect->h - dst_bottom_height;
     curr_dst.h = dst_bottom_height;
     if (!SDL_RenderTexture(renderer, texture, &curr_src, &curr_dst)) {
@@ -4474,6 +4475,7 @@ bool SDL_RenderTexture9Grid(SDL_Renderer *renderer, SDL_Texture *texture, const 
 
     // Bottom
     curr_src.y = srcrect->y + srcrect->h - bottom_height;
+    curr_src.h = bottom_height;
     curr_dst.y = dstrect->y + dstrect->h - dst_bottom_height;
     curr_dst.h = dst_bottom_height;
     if (!SDL_RenderTexture(renderer, texture, &curr_src, &curr_dst)) {


### PR DESCRIPTION
…m edges / corners in SDL_RenderTexture9Grid, to avoid issue where inadvertently using top height if the npatch existed on a larger texture than the drawn edge would cause too many pixels to be included in the bottom part of the render.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
